### PR TITLE
Save class labels as node attributes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ CLASSIFIERS = [
     'Topic :: Scientific/Engineering :: Bio-Informatics'
 ]
 INSTALL_REQUIRES = [
-    'networkx==1.11',
+    'networkx==2.4',
     'rdflib==4.2.1',
     'rdflib-jsonld',
     'requests',

--- a/src/onto2nx/owl_rdf.py
+++ b/src/onto2nx/owl_rdf.py
@@ -14,7 +14,7 @@ __all__ = [
 
 def parse_owl_rdf(iri):
     """Parses an OWL resource that's encoded in OWL/RDF into a NetworkX directional graph
-    
+
     :param str iri: The location of the OWL resource to be parsed by Ontospy
     :type iri: str
     :rtype: network.DiGraph
@@ -23,7 +23,7 @@ def parse_owl_rdf(iri):
     o = Ontospy(iri)
 
     for cls in o.classes:
-        g.add_node(cls.locale, type='Class')
+        g.add_node(cls.locale, type='Class', label=cls.bestLabel().strip('"'))
 
         for parent in cls.parents():
             g.add_edge(cls.locale, parent.locale, type='SubClassOf')

--- a/src/onto2nx/owl_xml.py
+++ b/src/onto2nx/owl_xml.py
@@ -56,10 +56,14 @@ class OWLParser(nx.DiGraph):
         self.graph['IRI'] = self.root.attrib.get('ontologyIRI')
 
         for el in self.root.findall('./owl:Declaration/owl:Class', OWL_NAMESPACES):
-            self.add_node(self.get_iri(el.attrib), type="Class")
+            self.add_node(
+                self.get_iri(el.attrib),
+                type='Class', label=self.get_label(el.attrib))
 
         for el in self.root.findall('./owl:Declaration/owl:NamedIndividual', OWL_NAMESPACES):
-            self.add_node(self.get_iri(el.attrib), type="NamedIndividual")
+            self.add_node(
+                self.get_iri(el.attrib),
+                type='NamedIndividual', label=self.get_label(el.attrib))
 
         for el in self.root.findall('./owl:SubClassOf', OWL_NAMESPACES):
             if len(el) != 2:
@@ -107,3 +111,7 @@ class OWLParser(nx.DiGraph):
             return self.strip_iri(attribs[IRI])
         elif AIRI in attribs:
             return self.strip_airi(attribs[AIRI])
+
+    def get_label(self, attribs):
+        # TODO: implement this
+        return ''


### PR DESCRIPTION
This PR does the following things:
* Update `networkx` dependency to a more recent version (1.11 -> 2.4, testing needed!)
* Save ontology class labels as `networkx` node attributes

So far, this is only properly implemented for RDF. If this feature is wanted, one could implement it for the other data types as well.
One could also think of extending this feature by allowing the user to specify which tags to extract.